### PR TITLE
Wrap switchUserWithId in try catch

### DIFF
--- a/packages/core/sdk/src/auth/internal/CoreStitchAuth.ts
+++ b/packages/core/sdk/src/auth/internal/CoreStitchAuth.ts
@@ -390,7 +390,11 @@ export default abstract class CoreStitchAuth<TStitchUser extends CoreStitchUser>
     if (credential.providerCapabilities.reusesExistingSession) {
       for (const [userId, authInfo] of this.allUsersAuthInfo) {
         if (authInfo.loggedInProviderType === credential.providerType) {
-          return Promise.resolve(this.switchToUserWithId(userId));
+          try {
+            return Promise.resolve(this.switchToUserWithId(userId));
+          } catch (error) {
+            return Promise.reject(error);
+          }
         }
       }
     }


### PR DESCRIPTION
Whenever an error is thrown from the switchToUserId call within the Promise.resolve it would go unhandled and crash the application. (Only seemed to happen In safari)